### PR TITLE
Do not consult base class for queries

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -74,7 +74,7 @@ module CollectiveIdea #:nodoc:
 
       def acts_as_nested_set_relate_children!
         has_many_children_options = {
-          :class_name => self.base_class.to_s,
+          :class_name => self.to_s,
           :foreign_key => parent_column_name,
           :primary_key => primary_column_name,
           :inverse_of => (:parent unless acts_as_nested_set_options[:polymorphic]),
@@ -92,7 +92,7 @@ module CollectiveIdea #:nodoc:
       end
 
       def acts_as_nested_set_relate_parent!
-        belongs_to :parent, :class_name => self.base_class.to_s,
+        belongs_to :parent, :class_name => self.to_s,
                             :foreign_key => parent_column_name,
                             :primary_key => primary_column_name,
                             :counter_cache => acts_as_nested_set_options[:counter_cache],

--- a/lib/awesome_nested_set/model.rb
+++ b/lib/awesome_nested_set/model.rb
@@ -145,7 +145,7 @@ module CollectiveIdea #:nodoc:
             end
           end
 
-          self.class.base_class.unscoped.nested_set_scope options
+          self.class.unscoped.nested_set_scope options
         end
 
         # Separate an other `nested_set_scope` for unscoped model
@@ -247,7 +247,7 @@ module CollectiveIdea #:nodoc:
         end
 
         def reload_target(target, position)
-          if target.is_a? self.class.base_class
+          if target.is_a? self.class
             target.reload
           elsif position != :root
             nested_set_scope.where(primary_column_name => target).first!

--- a/lib/awesome_nested_set/move.rb
+++ b/lib/awesome_nested_set/move.rb
@@ -38,7 +38,6 @@ module CollectiveIdea #:nodoc:
                  :to => :instance
 
         delegate :arel_table, :class, :to => :instance, :prefix => true
-        delegate :base_class, :to => :instance_class, :prefix => :instance
 
         def where_statement(left_bound, right_bound)
           instance_arel_table[left_column_name].in(left_bound..right_bound).
@@ -84,7 +83,7 @@ module CollectiveIdea #:nodoc:
 
         def lock_nodes_between!(left_bound, right_bound)
           # select the rows in the model between a and d, and apply a lock
-          instance_base_class.right_of(left_bound).left_of_right_side(right_bound).
+          instance_class.right_of(left_bound).left_of_right_side(right_bound).
                               select(primary_column_name).lock(true)
         end
 


### PR DESCRIPTION
We don't use STI, and this causes issues with Ja::Company and Company.
Basically, when we ask for the root of a node of type Ja::Company, we
want to get a Ja::Company, not a Company.
