### PR TITLE
Do not consult base class for queries

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -74,7 +74,7 @@ module CollectiveIdea #:nodoc:
 
       def acts_as_nested_set_relate_children!
         has_many_children_options = {
-          :class_name => self.base_class.to_s,
+          :class_name => self.to_s,
           :foreign_key => parent_column_name,
           :primary_key => primary_column_name,
           :inverse_of => (:parent unless acts_as_nested_set_options[:polymorphic]),
@@ -93,7 +93,7 @@ module CollectiveIdea #:nodoc:
 
       def acts_as_nested_set_relate_parent!
         options = {
-          :class_name => self.base_class.to_s,
+          :class_name => self.to_s,
           :foreign_key => parent_column_name,
           :primary_key => primary_column_name,
           :counter_cache => acts_as_nested_set_options[:counter_cache],


### PR DESCRIPTION
We don't use STI, and this causes issues with Ja::Company and Company.
Basically, when we ask for the root of a node of type Ja::Company, we
want to get a Ja::Company, not a Company.